### PR TITLE
CI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,13 +1,16 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python application
 
 on:
   push:
-    branches: [ main ]
+    branches: [ "main" ]
   pull_request:
-    #branches: [ main ]
+    # branches: [ "main" ]
+
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -15,19 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-
-    # USE OFFICIAL GOOGLE ACTION TO CREATE A CREDENTIALS JSON FILE
-    # ... https://github.com/google-github-actions/auth
-    #- id: 'auth'
-    #  name: 'Authenticate to Google Cloud'
-    #  uses: 'google-github-actions/auth@v0'
-    #  with:
-    #    # uses this encrypted secret set via github repo settings
-    #    # which is essentially a copy of the JSON credentials file contents (for the dev project)
-    #    credentials_json: '${{ secrets.GOOGLE_API_CREDENTIALS }}'
-    #    # this will create a credentials file with a randomized name
-    #    create_credentials_file:  true
+    - uses: actions/checkout@v4
 
     - name: Set up Python 3.10
       uses: actions/setup-python@v3
@@ -47,14 +38,23 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
+    # USE OFFICIAL GOOGLE ACTION TO CREATE A CREDENTIALS JSON FILE
+    # ... https://github.com/google-github-actions/auth
+    - id: 'auth'
+      name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@v2'
+      with:
+        # uses this encrypted secret set via github repo settings
+        # which is essentially a copy of the JSON credentials file contents
+        credentials_json: '${{ secrets.GOOGLE_API_CREDENTIALS }}'
+        # this will create a credentials file with a randomized name
+        create_credentials_file:  true
+
+
+    # RUN TESTS
     - name: Test with pytest
-      #env:
-        # access path of credentials file created by earlier auth step:
-        #GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }}
-        # GOOGLE_CREDENTIALS_FILEPATH: ${{ steps.auth.outputs.credentials_file_path }}
-        # GOOGLE_CREDENTIALS_FILEPATH: ${{ steps.auth.outputs.credentials_file_path }}
+      env:
+        GOOGLE_SHEETS_TEST_DOCUMENT_ID: ${{ secrets.GOOGLE_SHEETS_TEST_DOCUMENT_ID }}
+        GOOGLE_CREDENTIALS_FILEPATH: ${{ steps.auth.outputs.credentials_file_path }}
       run: |
-        echo "My Message: $MY_MESSAGE"
-        echo "My Message From Secrets: ${{ secrets.MY_MESSAGE }}"
-        echo "My Message From Env: ${{ env.MY_MESSAGE }}"
-        CI=true TEST_SLEEP=20 pytest
+        CI=true pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,15 +19,15 @@ jobs:
 
     # USE OFFICIAL GOOGLE ACTION TO CREATE A CREDENTIALS JSON FILE
     # ... https://github.com/google-github-actions/auth
-    - id: 'auth'
-      name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v0'
-      with:
-        # uses this encrypted secret set via github repo settings
-        # which is essentially a copy of the JSON credentials file contents (for the dev project)
-        credentials_json: '${{ secrets.GOOGLE_API_CREDENTIALS }}'
-        # this will create a credentials file with a randomized name
-        create_credentials_file:  true
+    #- id: 'auth'
+    #  name: 'Authenticate to Google Cloud'
+    #  uses: 'google-github-actions/auth@v0'
+    #  with:
+    #    # uses this encrypted secret set via github repo settings
+    #    # which is essentially a copy of the JSON credentials file contents (for the dev project)
+    #    credentials_json: '${{ secrets.GOOGLE_API_CREDENTIALS }}'
+    #    # this will create a credentials file with a randomized name
+    #    create_credentials_file:  true
 
     - name: Set up Python 3.10
       uses: actions/setup-python@v3
@@ -53,4 +53,7 @@ jobs:
         #GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }}
         GOOGLE_CREDENTIALS_FILEPATH: ${{ steps.auth.outputs.credentials_file_path }}
       run: |
+        echo "My Message: $MY_MESSAGE"
+        echo "My Message From Secrets: ${{ secrets.MY_MESSAGE }}"
+        echo "My Message From Env: ${{ env.MY_MESSAGE }}"
         CI=true TEST_SLEEP=20 pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    #branches: [ main ]
 
 jobs:
   build:
@@ -48,10 +48,11 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
     - name: Test with pytest
-      env:
+      #env:
         # access path of credentials file created by earlier auth step:
         #GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }}
-        GOOGLE_CREDENTIALS_FILEPATH: ${{ steps.auth.outputs.credentials_file_path }}
+        # GOOGLE_CREDENTIALS_FILEPATH: ${{ steps.auth.outputs.credentials_file_path }}
+        # GOOGLE_CREDENTIALS_FILEPATH: ${{ steps.auth.outputs.credentials_file_path }}
       run: |
         echo "My Message: $MY_MESSAGE"
         echo "My Message From Secrets: ${{ secrets.MY_MESSAGE }}"

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -15,14 +15,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
 
     # USE OFFICIAL GOOGLE ACTION TO CREATE A CREDENTIALS JSON FILE
     # ... https://github.com/google-github-actions/auth
-    # ... https://github.com/marketplace/actions/authenticate-to-google-cloud
     - id: 'auth'
       name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v2'
+      uses: 'google-github-actions/auth@v0'
       with:
         # uses this encrypted secret set via github repo settings
         # which is essentially a copy of the JSON credentials file contents (for the dev project)
@@ -53,7 +52,5 @@ jobs:
         # access path of credentials file created by earlier auth step:
         #GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }}
         GOOGLE_CREDENTIALS_FILEPATH: ${{ steps.auth.outputs.credentials_file_path }}
-        # for CI access to google sheets test document:
-        GOOGLE_SHEETS_TEST_DOCUMENT_ID: ${{ secrets.GOOGLE_SHEETS_TEST_DOCUMENT_ID }}
       run: |
         CI=true TEST_SLEEP=20 pytest


### PR DESCRIPTION
Testing / fixing the GitHub Actions CI build.

Error(s) with original approach (that works in previous repos):

```
Run google-github-actions/auth@v0

Error: The v0 series of google-github-actions/auth is no longer maintained. 
It will not receive updates, improvements, or security patches. 
Please upgrade to the latest supported versions: 
https://github.com/google-github-actions/auth

Error: google-github-actions/auth failed with: retry function failed after 1 attempt: 
the GitHub Action workflow must specify exactly one of "workload_identity_provider" or "credentials_json"! 
If you are specifying input values via GitHub secrets, ensure the secret is being injected into the environment. 
By default, secrets are not passed to workflows triggered from forks, including Dependabot.
```